### PR TITLE
Add basic server setup with welcome message and API docs redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "swagger-autogen": "^2.23.7",
     "swagger-ui-express": "^5.0.1",
     "validatorjs": "^3.22.1"
-},
-"devDependencies": {
+  },
+  "devDependencies": {
     "nodemon": "^3.1.0"
-}
+  },
+  "packageManager": "pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a"
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Basic route for the welcome message with a link to redirect to /api-docs
+app.get('/', (req, res) => {
+  res.send(`
+    Welcome to Shop Backend! <br>
+    <a href="/api-docs">Go to API Docs</a>
+  `);
+});
+
+// Redirect to /api-docs (Swagger)
+app.get('/api-docs', (req, res) => {
+  const swaggerUrl = process.env.SWAGGER_URL || 'http://localhost:3000/api-docs'; // Default to local if SWAGGER_URL is not set
+  res.redirect(swaggerUrl);
+});
+
+// **My Contribution: Basic server setup with routes for welcome message and API redirect**
+// - Pablo Zabaleta
+
+// Start the server
+app.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
Hi team,

I made a small update to the project. I added a basic server.js setup with two routes:

The main route (/) shows a "Welcome to Shop Backend!" message with a link to redirect to the /api-docs route.

The /api-docs route redirects to the Swagger documentation URL, which can be configured dynamically via the .env file. If the SWAGGER_URL environment variable is not set, it defaults to http://localhost:3000/api-docs for local development.

Please make sure to add your production Swagger URL (example, SWAGGER_URL=https://shopbackend-e75t.onrender.com/api-docs) in the .env file.

This is just a small step forward while waiting for the Swagger and database setup. I haven’t started working on my part yet, as I’d prefer to wait for those components to be implemented.

Additionally, I created a file db/database.js, although it’s empty for now. This might come in handy later.

**Note** I personally use a middleware folder for things like the error handler, but I haven’t added it in this case. Just something to consider moving forward.